### PR TITLE
fix: where `format` param is ignored by imgproxy

### DIFF
--- a/src/react/loaders/imgproxy-loader.tsx
+++ b/src/react/loaders/imgproxy-loader.tsx
@@ -39,7 +39,6 @@ export function ImgproxyLoaderProvider({
   );
 }
 
-
 export function useImgproxyLoader(
   options?: Partial<ImgproxyLoaderOptions>,
 ): ImageLoader {
@@ -57,7 +56,7 @@ export function useImgproxyLoader(
     const paramsSeparator = resolvedOptions.paramsSeparator ?? "/";
 
     if (format) {
-      parts.push(`format:${format}`);
+      parts.push(`f:${format}`);
     }
 
     if (imageOptions.width) {


### PR DESCRIPTION
## Problem

When using the `useImgproxyLoader` and `darthsim/imgproxy:v3.30.1` (latest Docker Image as of writing), the finalized image with the param `format:webp` is ignored.

Theoretically, it should work based on [the imgproxy documentation](https://docs.imgproxy.net/usage/processing#format), but it doesn't seem to work on my testing (repro steps below).

## Reproduction

> [!TIP]
> You can view the repro in [oh-image-demo.takayumidesu.workers.dev](https://oh-image-demo.takayumidesu.workers.dev/) and the repository in [takayumi/oh-image-demo](https://github.com/takayumi/oh-image-demo).

I deployed a `darthsim/imgproxy:v3.30.1` on `cdn.takayumi.com` for testing. No environment variables set, so everything is on the defaults.

Then, I tried loading using these settings:

```ts
const loaderNoDot = useImgproxyLoader({
	path: env.VITE_IMGPROXY_URL,
	placeholder: true,
	params: {
		quality: "80",
	},
});

const loaderWithDot = useImgproxyLoader({
	path: env.VITE_IMGPROXY_URL,
	placeholder: true,
	format: ".webp",
	params: {
		quality: "80",
	},
});

// the only one that successfully transforms the size
const loaderFNoDot = useImgproxyLoader({
	path: env.VITE_IMGPROXY_URL,
	placeholder: true,
	params: {
		quality: "80",
		f: "webp",
	},
});

const loaderFWithDot = useImgproxyLoader({
	path: env.VITE_IMGPROXY_URL,
	placeholder: true,
	params: {
		quality: "80",
		f: ".webp",
	},
});
```

## Fix

I've tried using it with `f:webp` and it works fine afterwards, so I made the loader use that instead.

The third example (appending `f:webp`) is [866 bytes](https://cdn.takayumi.com/format:webp/width:1920/height:64/quality:80/f:webp/plain/https://oh-image-demo.takayumidesu.workers.dev/img/sean.png).

Meanwhile, the other examples are 8.2 kilobytes.

## Future Considerations

### CSS Background Bug

As you can see in the fourth demo, the image seems to be adding a background with CSS and using the `src` attributes at the same time. Not sure what causes that, but it's probably better to keep it as a `src`.

### Custom Params Deduplication

Also, perhaps the `params` options should be deduplicated from the defaults if provided by the user? Not sure if that's a good API though.

### Default Blur Placeholder Not Working for Loaders (?)

Despite the docs saying placeholders are true, they don't seem to load in my demo.

```ts
const loader = useImgproxyLoader({
  path: "https://your-imgproxy-server.com",
  format: "webp",
  // placeholder: true, // Generate blurred placeholders (default: true)
});
```

## Further Reading

Someone implemented a TypeScript-compatible [imgproxy URL builder utility library](https://github.com/BitPatty/imgproxy-url-builder) already. Maybe you can refer to that for future implementations.

Looking forward to your feedback and thanks for making this project @lukonik.