### PR TITLE
feat(imgproxy): add signature option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "**/.DS_Store": true,
     "**/Thumbs.db": true,
     "**/node_modules": true,
-    "**/dist": true,
+    // "**/dist": true,
     "**/__screenshots__": true
   },
   "editor.codeActionsOnSave": {

--- a/playground/src/routes/__root.tsx
+++ b/playground/src/routes/__root.tsx
@@ -39,87 +39,87 @@ function RootComponent() {
   return (
     <NetlifyLoaderProvider>
       <WordpressLoaderProvider path={import.meta.env["VITE_WORDPRESS_PATH"]}>
-        <ContentfulLoaderProvider path={import.meta.env["VITE_CONTENTFUL_PATH"]}>
+        <ContentfulLoaderProvider
+          path={import.meta.env["VITE_CONTENTFUL_PATH"]}
+        >
           <KontentLoaderProvider path="http://kontent.ai">
-            <CloudinaryLoaderProvider
-              client={cld}
-            >
+            <CloudinaryLoaderProvider client={cld}>
               <CloudflareLoaderProvider path="http://cloudflare.com">
-                <ImgproxyLoaderProvider path="http://localhost:8080/insecure">
-                <div className="container mx-auto pt-20 flex justify-center">
-                  <div>
-                    <header>
-                      <nav className="flex items-center gap-4 mb-20">
-                        <Link
-                          to="/image"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          Image Component
-                        </Link>
-                        <Link
-                          to="/cloudflare"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          Cloudflare Loader
-                        </Link>
-                        <Link
-                          to="/cloudinary"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          Cloudinary Loader
-                        </Link>
-                        <Link
-                          to="/imgproxy"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          Imgproxy Loader
-                        </Link>
-                        <Link
-                          to="/vite-image"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          Vite Image
-                        </Link>
-                        <Link
-                          to="/kontent"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          Kontent
-                        </Link>
-                        <Link
-                          to="/contentful"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          Contentful
-                        </Link>
-                        <Link
-                          to="/wordpress"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          WordPress
-                        </Link>
-                        <Link
-                          to="/netlify"
-                          style={buttonStyle}
-                          activeProps={{ style: activeButtonStyle }}
-                        >
-                          Netlify
-                        </Link>
-                      </nav>
-                    </header>
-                    <main>
-                      <Outlet />
-                    </main>
+                <ImgproxyLoaderProvider path="http://localhost:8080">
+                  <div className="container mx-auto pt-20 flex justify-center">
+                    <div>
+                      <header>
+                        <nav className="flex items-center gap-4 mb-20">
+                          <Link
+                            to="/image"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            Image Component
+                          </Link>
+                          <Link
+                            to="/cloudflare"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            Cloudflare Loader
+                          </Link>
+                          <Link
+                            to="/cloudinary"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            Cloudinary Loader
+                          </Link>
+                          <Link
+                            to="/imgproxy"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            Imgproxy Loader
+                          </Link>
+                          <Link
+                            to="/vite-image"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            Vite Image
+                          </Link>
+                          <Link
+                            to="/kontent"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            Kontent
+                          </Link>
+                          <Link
+                            to="/contentful"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            Contentful
+                          </Link>
+                          <Link
+                            to="/wordpress"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            WordPress
+                          </Link>
+                          <Link
+                            to="/netlify"
+                            style={buttonStyle}
+                            activeProps={{ style: activeButtonStyle }}
+                          >
+                            Netlify
+                          </Link>
+                        </nav>
+                      </header>
+                      <main>
+                        <Outlet />
+                      </main>
+                    </div>
                   </div>
-                </div>
                 </ImgproxyLoaderProvider>
               </CloudflareLoaderProvider>
             </CloudinaryLoaderProvider>

--- a/src/loaders/imgproxy/imgproxy-loader.tsx
+++ b/src/loaders/imgproxy/imgproxy-loader.tsx
@@ -103,6 +103,10 @@ export const {
       zoom: { orders: ["x", "y"] },
     },
   },
-  ({ path, params, imageOptions }) =>
-    `${path}/${params}/plain/${imageOptions.src}`,
+  ({ path, params, imageOptions, options }) => {
+    if (options.signature !== undefined) {
+      return `${path}/${options.signature}/${params}/plain/${imageOptions.src}`;
+    }
+    return `${path}/${params}/plain/${imageOptions.src}`;
+  },
 );

--- a/src/loaders/imgproxy/imgproxy-options.ts
+++ b/src/loaders/imgproxy/imgproxy-options.ts
@@ -468,5 +468,5 @@ export interface ImgproxyGlobalOptions extends BaseGlobalLoaderOptions<ImgproxyO
    * - \`"insecure"\` sets it to insecure
    * - \`string\` sets the custom signature
    */
-  signature?: "insecure" | (string & {});
+  signature?: "insecure" | (string & {}) | undefined;
 }

--- a/src/loaders/imgproxy/imgproxy-options.ts
+++ b/src/loaders/imgproxy/imgproxy-options.ts
@@ -1,6 +1,6 @@
 import type {
   BaseGlobalLoaderOptions,
-  BaseLoaderOptions
+  BaseLoaderOptions,
 } from "../base-loader-options";
 
 type ResizeType = "fit" | "fill" | "fill-down" | "force" | "auto";
@@ -462,4 +462,11 @@ export type ImgproxyTransforms = Partial<{
 }>;
 
 export type ImgproxyOptions = BaseLoaderOptions<ImgproxyTransforms>;
-export type ImgproxyGlobalOptions = BaseGlobalLoaderOptions<ImgproxyTransforms>;
+export interface ImgproxyGlobalOptions extends BaseGlobalLoaderOptions<ImgproxyOptions> {
+  /**
+   * If \`undefined\`, won't set anything (this is for backward compatibility and will be removed in future versions, where by default it will be "insecure").
+   * - \`"insecure"\` sets it to insecure
+   * - \`string\` sets the custom signature
+   */
+  signature?: "insecure" | (string & {});
+}

--- a/src/loaders/loader-factory-types.ts
+++ b/src/loaders/loader-factory-types.ts
@@ -28,10 +28,11 @@ export type LoaderParamsResolver<K> = (options: {
   paramSeparator: string;
 }) => string[];
 
-export type LoaderUrlResolved = (options: {
+export type LoaderUrlResolved<T> = (options: {
   imageOptions: ImageLoaderOptions;
   params: string;
   path: string;
+  options: T;
 }) => string;
 
 export type LoaderOrders = Record<

--- a/src/loaders/loader-factory.tsx
+++ b/src/loaders/loader-factory.tsx
@@ -13,7 +13,7 @@ import type {
 export default function loaderFactory<
   K extends BaseLoaderTransforms,
   T extends BaseGlobalLoaderOptions<K>,
->(defaults: T, config: LoaderFactoryConfig, urlResolver: LoaderUrlResolved) {
+>(defaults: T, config: LoaderFactoryConfig, urlResolver: LoaderUrlResolved<T>) {
   const loaderContext = createContext<T>(defaults);
 
   function useLoaderContext() {
@@ -42,6 +42,10 @@ export default function loaderFactory<
       console.warn("Path is not provided");
       return () => undefined;
     }
+    const mergedOptions = {
+      ...context,
+      ...options,
+    };
     return (imageOptions: ImageLoaderOptions) => {
       const defaultTransform = imageOptions.isPlaceholder
         ? context.placeholder
@@ -79,6 +83,7 @@ export default function loaderFactory<
         imageOptions,
         params: resolvedParams,
         path,
+        options: mergedOptions,
       });
     };
   };

--- a/tests/browser/loader-factory.test.tsx
+++ b/tests/browser/loader-factory.test.tsx
@@ -92,7 +92,8 @@ describe("loaderFactory", () => {
 
     expect(urlResolver).toHaveBeenCalledWith({
       imageOptions,
-      params: "width,100&height,100&q,80", 
+      options: defaults,
+      params: "width,100&height,100&q,80",
       path: defaults.path,
     });
   });

--- a/tests/browser/loaders/imgproxy.test.tsx
+++ b/tests/browser/loaders/imgproxy.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   describeBooleanOption,
   describeImageOptions,
@@ -9,6 +9,7 @@ import {
 import { useImgproxyLoader } from "../../../src/loaders/imgproxy/imgproxy-loader";
 import type { ImgproxyTransforms } from "../../../src/loaders/imgproxy/imgproxy-options";
 import { chai } from "vitest";
+import { renderHook } from "vitest-browser-react";
 chai.config.truncateThreshold = 100000;
 describe("imgproxy", () => {
   const optionSeparator = ":";
@@ -44,6 +45,29 @@ describe("imgproxy", () => {
     (options) => useImgproxyLoader(options),
     ":",
   );
+
+  describe("loader", () => {
+    async function createLoader(signature?: string) {
+      const { result } = await renderHook(() =>
+        useImgproxyLoader({
+          path: "http://imgproxy.net",
+          signature: signature,
+        }),
+      );
+      return result.current({
+        src: "test",
+      });
+    }
+    it("should return insecure when signature is undefined", async () => {
+      expect(await createLoader()).not.toContain("insecure");
+    });
+    it("should return signature when signature is defined", async () => {
+      expect(await createLoader("random_hash")).toContain("random_hash");
+    });
+    it("should return insecure when insecure is set", async () => {
+      expect(await createLoader("insecure")).toContain("insecure");
+    });
+  });
 
   describeOption("adjust", {}, "::");
   describeOption(

--- a/website/src/data/loaders/imgproxy.ts
+++ b/website/src/data/loaders/imgproxy.ts
@@ -13,6 +13,7 @@ export const imgproxy = {
       quality: 10,
       format: "webp",
     },
+    signature:undefined
   },
   `,
   interface: `type ResizeType = "fit" | "fill" | "fill-down" | "force" | "auto";
@@ -194,5 +195,13 @@ export interface ImgproxyTransforms {
   expires?: number;
   filename?: string;
   preset?: string[];
+}`,
+  globalOptions: `export interface ImgproxyGlobalOptions {
+  /**
+   * If \`undefined\`, won't set anything (this is for backward compatibility and will be removed in future versions, where by default it will be "insecure").
+   * - \`"insecure"\` sets it to insecure
+   * - \`string\` sets the custom signature
+   */
+  signature?: "insecure" | (string & {});
 }`,
 };

--- a/website/src/pages/docs/loaders/[...slug].astro
+++ b/website/src/pages/docs/loaders/[...slug].astro
@@ -95,6 +95,14 @@ function App() {
     title={`${loader.title} Default Config`}
   />
 
+  {loader.globalOptions && (
+    <>
+      <h2>Global Options</h2>
+      <p>Everything in transformation options in addition to:</p>
+      <Code code={loader.globalOptions} lang="ts" title={`${loader.title} Global Options`} />
+    </>
+  )}
+
   <h2>Transforms Option</h2>
   <p>
     Below is the transformation


### PR DESCRIPTION
closes #47 

add new signature option to imgproxy loader. 

It can have three different values:
* undefined: won't set anything (this is for backward compatibility and will be removed in future versions, where by default it will be "insecure"
* insecure: sets it to insecure
* string sets the custom signature

usage:

```
  useImgproxyLoader({
     signature:"insecure"
  })
  
  useImgproxyLoader({
       signature:"signature_key"
  }
  )

```

can be set globally as well
```
  <ImgproxyLoaderProvider signature="signature_key" </ImgproxyLoaderProvider>
```

@takayumi  what do you think about it